### PR TITLE
Use exact version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:16.04
 
-ENV API_VERSION develop
-
 RUN apt-get update; \
     apt-get install -y --fix-missing python2.7 net-tools python-pip git wget unzip maven mysql-client openjdk-8-jdk; \
     wget http://download.java.net/glassfish/4.1/release/glassfish-4.1.zip; \
@@ -15,12 +13,13 @@ RUN apt-get update; \
 
 WORKDIR /apis
 
-RUN mkdir wars; \
-git clone https://github.com/caposseleDigicat/DSPRODUCTCATALOG2.git
+RUN mkdir wars
+
+RUN git clone https://github.com/CDECatapult/DSPRODUCTCATALOG2.git
 
 WORKDIR DSPRODUCTCATALOG2
 
-RUN git checkout Synchronicity; \
+RUN git checkout 59b2c360bc264b3e893548df739b59348a09720d; \
     sed -i 's/jdbc\/sample/jdbc\/pcatv2/g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \
@@ -37,7 +36,7 @@ RUN git clone https://github.com/FIWARE-TMForum/DSPRODUCTORDERING.git
 
 WORKDIR DSPRODUCTORDERING
 
-RUN git checkout $API_VERSION; \
+RUN git checkout 0a34fdce055a249740de89294c2b9f760b02d2f6; \
     sed -i 's/jdbc\/sample/jdbc\/podbv2/g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \
@@ -54,7 +53,7 @@ RUN git clone https://github.com/FIWARE-TMForum/DSPRODUCTINVENTORY.git
 
 WORKDIR DSPRODUCTINVENTORY
 
-RUN git checkout $API_VERSION; \
+RUN git checkout 5c94bd874d08f84b9a58a890ebe0580d824364dc; \
 sed -i 's/jdbc\/sample/jdbc\/pidbv2/g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \
@@ -71,7 +70,7 @@ RUN git clone https://github.com/FIWARE-TMForum/DSPARTYMANAGEMENT.git
 
 WORKDIR DSPARTYMANAGEMENT
 
-RUN git checkout $API_VERSION; \
+RUN git checkout 1efd63fed97727bde09b4b44c312ff0692d1c082; \
 sed -i 's/jdbc\/sample/jdbc\/partydb/g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \
@@ -88,7 +87,7 @@ RUN git clone https://github.com/FIWARE-TMForum/DSBILLINGMANAGEMENT.git
 
 WORKDIR DSBILLINGMANAGEMENT
 
-RUN git checkout $API_VERSION; \
+RUN git checkout 837279cd99a682ea98f96de9aeace48bdfa2dba6; \
 sed -i 's/jdbc\/sample/jdbc\/bmdbv2/g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \
@@ -105,7 +104,7 @@ RUN git clone https://github.com/FIWARE-TMForum/DSCUSTOMER.git
 
 WORKDIR DSCUSTOMER
 
-RUN git checkout $API_VERSION; \
+RUN git checkout 68e82a8f989a5a53022ba65e7ccb592bf1f276a4; \
 sed -i 's/jdbc\/sample/jdbc\/customerdbv2/g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
 sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \
@@ -122,7 +121,7 @@ RUN git clone https://github.com/FIWARE-TMForum/DSUSAGEMANAGEMENT.git
 
 WORKDIR DSUSAGEMANAGEMENT
 
-RUN git checkout $API_VERSION; \
+RUN git checkout 4e4fc01c6f8a6e0a755e3a47cbc31fd763a9c934; \
     sed -i 's/jdbc\/sample/jdbc\/usagedbv2/g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \
@@ -145,4 +144,3 @@ EXPOSE 4848
 EXPOSE 8080
 
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ RUN apt-get update; \
 WORKDIR /apis
 
 RUN mkdir wars; \
-git clone https://github.com/FIWARE-TMForum/DSPRODUCTCATALOG2.git
+git clone https://github.com/caposseleDigicat/DSPRODUCTCATALOG2.git
 
 WORKDIR DSPRODUCTCATALOG2
 
-RUN git checkout $API_VERSION; \
+RUN git checkout Synchronicity; \
     sed -i 's/jdbc\/sample/jdbc\/pcatv2/g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<provider>org\.eclipse\.persistence\.jpa\.PersistenceProvider<\/provider>/ /g' ./src/main/resources/META-INF/persistence.xml; \
     sed -i 's/<property name="eclipselink\.ddl-generation" value="drop-and-create-tables"\/>/ /g' ./src/main/resources/META-INF/persistence.xml; \


### PR DESCRIPTION
Use same version as current working image so that we can be sure we are not using a branch remotely updated.